### PR TITLE
Renaming

### DIFF
--- a/src/main/scala/de/fosd/typechef/crefactor/backend/CRefactor.scala
+++ b/src/main/scala/de/fosd/typechef/crefactor/backend/CRefactor.scala
@@ -87,7 +87,7 @@ trait CRefactor
         val env = morpheus.getEnv(scope).asInstanceOf[Env]
         val ctx = morpheus.getASTEnv.featureExpr(element)
 
-        (hasConflictingType(env.varEnv(name), ctx, morpheus)
+        ! (hasConflictingType(env.varEnv(name), ctx, morpheus)
             || hasConflictingStructOrUnion(name, env)
             || hasConflictingType(env.typedefEnv(name), ctx, morpheus))
     }

--- a/src/main/scala/de/fosd/typechef/crefactor/backend/CRefactor.scala
+++ b/src/main/scala/de/fosd/typechef/crefactor/backend/CRefactor.scala
@@ -36,7 +36,8 @@ trait CRefactor
     def isSystemLinkedName(name: String) = SystemLinker.allLibs.par.contains(name)
 
     def isValidInProgram(name: Opt[String], morpheus: Morpheus): Boolean =
-        (morpheus.getModuleInterface != null) && morpheus.getModuleInterface.isListed(name, morpheus.getFM)
+      ! (morpheus.getModuleInterface != null &&
+        morpheus.getModuleInterface.isListed(name, morpheus.getFM))
 
     def generateValidNewName(id: Id, stmt: Opt[AST], morpheus: Morpheus, appendix: Int = 1): String = {
         val newName = id.name + "_" + appendix

--- a/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CExtractFunction.scala
+++ b/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CExtractFunction.scala
@@ -169,7 +169,7 @@ object CExtractFunction extends CRefactor with IntraCFG {
             val newFDefForward = genFDefForward(parentFunction, morpheus, specifiers, declarator)
             val newFDefForwardOpt = genFDefExternal(parentFunction, newFDefForward, morpheus)
 
-            if (isValidInProgram(Opt(newFDefOpt.feature, fName), morpheus))
+            if (!isValidInProgram(Opt(newFDefOpt.feature, fName), morpheus))
                 return Left(Configuration.getInstance().getConfig("default.error.invalidName"))
 
             // generate function fCall

--- a/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CRenameIdentifier.scala
+++ b/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CRenameIdentifier.scala
@@ -31,8 +31,12 @@ object CRenameIdentifier extends CRefactor {
         // TODO Compare with canRefactor
         if (!isValidName(nid))
             Left(Configuration.getInstance().getConfig("default.error.invalidName"))
-        else if (isValidInProgram(Opt(parentOpt(id, morpheus.getASTEnv).feature, nid), morpheus))
-            Left(Configuration.getInstance().getConfig("default.error.invalidName"))
+        else if (!rid.forall { // TODO: could be limited to external declarations
+          r =>
+            val ropt = Opt(parentOpt(r, morpheus.getASTEnv).feature, nid)
+            isValidInProgram(ropt, morpheus)
+        })
+          Left(Configuration.getInstance().getConfig("default.error.invalidName"))
         else if (!rid.forall(isValidInModule(nid, _, morpheus)))
             Left(Configuration.getInstance().getConfig("engine.rename.failed.shadowing"))
         // isWritable - with workaround for openssl casestudy with incomplete paths

--- a/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CRenameIdentifier.scala
+++ b/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CRenameIdentifier.scala
@@ -33,7 +33,7 @@ object CRenameIdentifier extends CRefactor {
             Left(Configuration.getInstance().getConfig("default.error.invalidName"))
         else if (isValidInProgram(Opt(parentOpt(id, morpheus.getASTEnv).feature, nid), morpheus))
             Left(Configuration.getInstance().getConfig("default.error.invalidName"))
-        else if (rid.exists(isValidInModule(nid, _, morpheus)))
+        else if (!rid.forall(isValidInModule(nid, _, morpheus)))
             Left(Configuration.getInstance().getConfig("engine.rename.failed.shadowing"))
         // isWritable - with workaround for openssl casestudy with incomplete paths
         else if (!rid.par.forall(isWritable(_, morpheus)))

--- a/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CRenameIdentifier.scala
+++ b/src/main/scala/de/fosd/typechef/crefactor/backend/engine/CRenameIdentifier.scala
@@ -33,7 +33,7 @@ object CRenameIdentifier extends CRefactor {
             Left(Configuration.getInstance().getConfig("default.error.invalidName"))
         else if (!rid.forall { // TODO: could be limited to external declarations
           r =>
-            val ropt = Opt(parentOpt(r, morpheus.getASTEnv).feature, nid)
+            val ropt = Opt(morpheus.getASTEnv.featureExpr(parentOpt(r, morpheus.getASTEnv)), nid)
             isValidInProgram(ropt, morpheus)
         })
           Left(Configuration.getInstance().getConfig("default.error.invalidName"))


### PR DESCRIPTION
@aJanker I changed the exists quantifier in !forall, so it reflects the name of the isValidInProgram function.
Additionally, isValidInProgram is now checked for all presence conditions of referenced identifiers; this is actually to much, as we only have to check externally visible declarations!
